### PR TITLE
docs: improve name for installing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You will need `curl` and `jq` installed. Define your `OPENAI_API_KEY`
 using `set -U OPENAI_API_KEY <your key>` and then install the plugin:
 
 ```fish
-$ omf install fish-ai
+$ omf install ai
 ```
 
 ## Usage


### PR DESCRIPTION
hello @derekstavis !

i start using you awesome plugin and when i tried to search:

```
⋊> ~/D/github omf search fish-ai                                                     15:37:44
Plugins

Themes
⋊> ~/D/github
```

search is empty. install by `fish-ai` works, but i think 

```
omf install ai
```

more correlates better with final terminal command `ai <...>` . 